### PR TITLE
Build cleanup for EPICS 7 and Asyn 4-32+

### DIFF
--- a/modbusApp/src/Makefile
+++ b/modbusApp/src/Makefile
@@ -17,6 +17,8 @@ INC += drvModbusAsyn.h
 
 LIBRARY_IOC = modbus
 
+USR_CFLAGS += -DUSE_TYPED_RSET
+
 LIB_SRCS += drvModbusAsyn.c
 LIB_SRCS += modbusInterpose.c
 LIB_SRCS += testModbusSyncIO.cpp

--- a/modbusApp/src/testModbusSyncIO.cpp
+++ b/modbusApp/src/testModbusSyncIO.cpp
@@ -40,9 +40,7 @@ public:
 protected:
     /** Values used for pasynUser->reason, and indexes into the parameter library. */
     int P_SyncIO_;
-    #define FIRST_COMMAND P_SyncIO_
     int P_LockIO_;
-    #define LAST_COMMAND P_LockIO_
  
 private:
     /* Our data */
@@ -57,15 +55,12 @@ private:
     void      *pasynInt32OutputPvt_;
 };
 
-#define NUM_PARAMS (&LAST_COMMAND - &FIRST_COMMAND + 1)
-
 
 /** Constructor for the testModbusSyncIO class.
   * Calls constructor for the asynPortDriver base class. */
 testModbusSyncIO::testModbusSyncIO(const char *portName, const char *inputDriver, const char* outputDriver) 
    : asynPortDriver(portName, 
                     1, /* maxAddr */ 
-                    (int)NUM_PARAMS,
                     asynInt32Mask | asynDrvUserMask, /* Interface mask */
                     0, /* Interrupt mask */
                     ASYN_CANBLOCK, /* asynFlags.  This driver blocks and it is not multi-device*/


### PR DESCRIPTION
Hi Mark,

These commits clean up compiler warnings from the modbus module when building against recent Base versions and Asyn 4-32 or later. The asynPortDriver change does of course now require the newer Asyn.

- Andrew
