### PR TITLE
Fix docs for STRING_HIGH_LOW and STRING_LOW_HIGH register data types

### DIFF
--- a/documentation/modbusDoc.html
+++ b/documentation/modbusDoc.html
@@ -1106,7 +1106,7 @@ asynOctetSetInputEos("Koyo1",0,"\r\n")
       </tr>
       <tr>
         <td>
-          11 </td>
+          13 </td>
         <td>
           STRING_HIGH_LOW </td>
         <td>
@@ -1115,7 +1115,7 @@ asynOctetSetInputEos("Koyo1",0,"\r\n")
       </tr>
       <tr>
         <td>
-          11 </td>
+          14 </td>
         <td>
           STRING_LOW_HIGH </td>
         <td>


### PR DESCRIPTION
I believe the documentation for the "Modbus register data types" section is incorrect for STRING_HIGH_LOW and STRING_LOW_HIGH. The modbusDataType value for each currently shows 11 which is also the value for STRING_HIGH.

From what I can see in the modbusDataType_t enum and in testing, STRING_HIGH_LOW should be 13 and STRING_LOW_HIGH should be 14. This commit updates the page modbusDoc.html.