### PR TITLE
Support specifying string length per PV

### DIFF
--- a/documentation/modbusDoc.html
+++ b/documentation/modbusDoc.html
@@ -1840,12 +1840,12 @@ field(INP,"@asyn(portName,offset,timeout)drvUser")
   <p>
     asynOctet device support is selected with</p>
   <pre>field(DTYP,"asynOctetRead")
-field(INP,"@asyn(portName,offset,timeout)drvUser")
+field(INP,"@asyn(portName,offset,timeout)drvUser[=number_of_characters]")
     </pre>
   <p>
     or</p>
   <pre>field(DTYP,"asynOctetWrite")
-field(INP,"@asyn(portName,offset,timeout)drvUser")
+field(INP,"@asyn(portName,offset,timeout)drvUser[=number_of_characters]")
     </pre>
   <p>
     asynOctet device support is used to read or write strings of up to 250 characters.</p>
@@ -1853,10 +1853,12 @@ field(INP,"@asyn(portName,offset,timeout)drvUser")
     Note: The 0 terminating byte at the end of the string in a waveform record or stringout
     record is not written to the Modbus device.</p>
   <p>
-    Note: On input number of characters read from the Modbus device will be the lesser
+    Note: On input the number of characters read from the Modbus device will be the lesser
     of:<br />
     - the number of characters in the record minus the terminating 0 byte (39 for stringin,
     NELM-1 for waveform) or
+    <br />
+    - the number of characters specified after drvUser (minus the terminating 0 byte) or
     <br />
     - the number of characters contained in the registers defined modbusLength argument
     to drvModbusAsynConfigure (modbusLength or modbusLength*2 depending on whether the
@@ -1864,7 +1866,7 @@ field(INP,"@asyn(portName,offset,timeout)drvUser")
   <p>
     The string will be truncated if any of the characters read from Modbus is a 0 byte,
     but there is no guarantee that the last character in the string is followed by a
-    0 byte in the Modbus registers. Generally either modbusLength or NELM in the waveform
+    0 byte in the Modbus registers. Generally either number_of_characters or NELM in the waveform
     record should be used to define the correct length for the string.
   </p>
   <table border="1" cellpadding="2" cellspacing="2" style="text-align: left">

--- a/documentation/modbusDoc.html
+++ b/documentation/modbusDoc.html
@@ -1330,7 +1330,7 @@ field(INP,"@asynMask(portName,offset,mask,timeout)drvUser")
       </tr>
       <tr>
         <td>
-          6 </td>
+          6, 16 </td>
         <td>
           16-bit word </td>
         <td>

--- a/modbusApp/src/drvModbusAsyn.cpp
+++ b/modbusApp/src/drvModbusAsyn.cpp
@@ -73,6 +73,11 @@ typedef struct {
     const char *dataTypeString;
 } modbusDataTypeStruct;
 
+struct modbusDrvUser_t {
+    modbusDataType_t dataType;
+    int              len;
+};
+
 static modbusDataTypeStruct modbusDataTypes[MAX_MODBUS_DATA_TYPES] = {
     {dataTypeUInt16,        MODBUS_UINT16_STRING},    
     {dataTypeInt16SM,       MODBUS_INT16_SM_STRING},    
@@ -135,6 +140,7 @@ drvModbusAsyn::drvModbusAsyn(const char *portName, const char *octetPortName,
     modbusLength_(modbusLength),
     absoluteAddressing_(false),
     dataType_(dataType),
+    drvUser_(NULL),
     data_(0),
     pollDelay_(pollMsec/1000.),
     forceCallback_(false),
@@ -246,6 +252,11 @@ drvModbusAsyn::drvModbusAsyn(const char *portName, const char *octetPortName,
      * data for asynInt32Array writes. */
     data_ = (epicsUInt16 *) callocMustSucceed(modbusLength_, sizeof(epicsUInt16), functionName);
 
+    /* Allocate and initialize the default drvUser structure */
+    drvUser_ = (modbusDrvUser_t *) callocMustSucceed(1, sizeof(modbusDrvUser_t), functionName);
+    drvUser_->dataType = dataType_;
+    drvUser_->len = -1;
+
     /* Connect to asyn octet port with asynOctetSyncIO */
     status = pasynOctetSyncIO->connect(octetPortName, 0, &pasynUserOctet_, 0);
     if (status != asynSuccess) {
@@ -289,7 +300,7 @@ drvModbusAsyn::drvModbusAsyn(const char *portName, const char *octetPortName,
 
 }
 
-
+
 /* asynDrvUser routines */
 asynStatus drvModbusAsyn::drvUserCreate(asynUser *pasynUser,
                                         const char *drvInfo,
@@ -303,10 +314,26 @@ asynStatus drvModbusAsyn::drvUserCreate(asynUser *pasynUser,
     /* We are passed a string that identifies this command.
      * Set dataType and/or pasynUser->reason based on this string */
 
-    pasynUser->drvUser = &dataType_;
+    struct drvInfoRAII_t {
+        char *str;
+        drvInfoRAII_t(const char *drvInfo) : str(epicsStrDup(drvInfo)) {
+        }
+        ~drvInfoRAII_t() {
+            free(str);
+        }
+    } drvInfoRAII(drvInfo);
+
+    /* Everything after an '=' sign is optional, strip it for now */
+    char *local_drvInfo = drvInfoRAII.str;
+    char *equal_sign;
+    if ((equal_sign = strchr(local_drvInfo, '='))) {
+        equal_sign[0] = '\0';
+    }
+
+    pasynUser->drvUser = drvUser_;
     for (i=0; i<MAX_MODBUS_DATA_TYPES; i++) {
         pstring = modbusDataTypes[i].dataTypeString;
-        if (epicsStrCaseCmp(drvInfo, pstring) == 0) {
+        if (epicsStrCaseCmp(local_drvInfo, pstring) == 0) {
             pasynManager->getAddr(pasynUser, &offset);
             if (checkOffset(offset)) {
                 asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
@@ -314,7 +341,39 @@ asynStatus drvModbusAsyn::drvUserCreate(asynUser *pasynUser,
                           driverName, functionName, this->portName, offset);
                 return asynError;
             }
-            pasynUser->drvUser = &modbusDataTypes[i].dataType;
+            modbusDataType_t dataType = modbusDataTypes[i].dataType;
+            int len = -1;
+            if (equal_sign) {
+                switch (dataType) {
+                    case dataTypeStringHigh:
+                    case dataTypeStringLow:
+                    case dataTypeStringHighLow:
+                    case dataTypeStringLowHigh:
+                        char *endptr;
+                        len = strtol(equal_sign + 1, &endptr, 0);
+                        if (endptr[0] != '\0' || len < 0) {
+                            asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
+                                      "%s::%s port %s invalid string length: %s\n",
+                                      driverName, functionName, this->portName, equal_sign + 1);
+                            return asynError;
+                        }
+                        break;
+
+                    default:
+                        asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
+                                  "%s::%s port %s invalid drvUser: %s\n",
+                                  driverName, functionName, this->portName, drvInfo);
+                        return asynError;
+                }
+            }
+
+            /* Update pasynUser->drvUser if needed */
+            if (dataType != dataType_ || len != -1) {
+                modbusDrvUser_t *drvUser = (modbusDrvUser_t *) callocMustSucceed(1, sizeof(modbusDrvUser_t), functionName);
+                drvUser->dataType = dataType;
+                drvUser->len = len;
+                pasynUser->drvUser = drvUser;
+            }
             pasynUser->reason = P_Data;
             if (pptypeName) *pptypeName = epicsStrDup(MODBUS_DATA_STRING);
             if (psize) *psize = sizeof(MODBUS_DATA_STRING);
@@ -329,6 +388,19 @@ asynStatus drvModbusAsyn::drvUserCreate(asynUser *pasynUser,
     return asynPortDriver::drvUserCreate(pasynUser, drvInfo, pptypeName, psize);
 
 }
+
+
+asynStatus drvModbusAsyn::drvUserDestroy(asynUser *pasynUser)
+{
+    if (pasynUser->drvUser != drvUser_) {
+        free(pasynUser->drvUser);
+    }
+
+    pasynUser->drvUser = NULL;
+
+    return asynSuccess;
+}
+
 
 /***********************/
 /* asynCommon routines */
@@ -1015,6 +1087,8 @@ asynStatus drvModbusAsyn::readOctet(asynUser *pasynUser, char *data, size_t maxC
     int modbusFunction;
     static const char *functionName="readOctet";
     
+    maxChars = getStringLen(pasynUser, maxChars);
+
     *nactual = 0;
     pasynManager->getAddr(pasynUser, &offset);
     if (function == P_Data) {
@@ -1073,6 +1147,8 @@ asynStatus drvModbusAsyn::writeOctet (asynUser *pasynUser, const char *data, siz
     int bufferLen;
     asynStatus status;
     static const char *functionName="writeOctet";
+
+    maxChars = getStringLen(pasynUser, maxChars);
 
     pasynManager->getAddr(pasynUser, &offset);
     if (absoluteAddressing_) {
@@ -1375,7 +1451,7 @@ void drvModbusAsyn::readPoller()
                               driverName, functionName, this->portName, offset, modbusLength_);
                     break;
                 }
-                readPlcString(dataType, offset, stringBuffer, sizeof(stringBuffer), &bufferLen);
+                readPlcString(dataType, offset, stringBuffer, getStringLen(pasynUser, sizeof(stringBuffer)), &bufferLen);
                 /* Set the status flag in pasynUser so I/O Intr scanned records can set alarm status */
                 pasynUser->auxStatus = ioStatus_;
                 asynPrint(pasynUserSelf, ASYN_TRACE_FLOW,
@@ -1779,11 +1855,23 @@ modbusDataType_t drvModbusAsyn::getDataType(asynUser *pasynUser)
 {
     modbusDataType_t dataType;
     if (pasynUser->drvUser) {
-        dataType = *(modbusDataType_t *)pasynUser->drvUser;
+        dataType = ((modbusDrvUser_t *)pasynUser->drvUser)->dataType;
     } else {
         dataType = dataType_;
     }
     return dataType;
+}
+
+int drvModbusAsyn::getStringLen(asynUser *pasynUser, size_t maxLen)
+{
+    size_t len = maxLen;
+
+    if (pasynUser->drvUser) {
+        int drvlen = ((modbusDrvUser_t *)pasynUser->drvUser)->len;
+        if (drvlen > -1 && (size_t)drvlen < maxLen)
+            len = drvlen;
+    }
+    return len;
 }
 
 asynStatus drvModbusAsyn::checkOffset(int offset)

--- a/modbusApp/src/drvModbusAsyn.h
+++ b/modbusApp/src/drvModbusAsyn.h
@@ -73,6 +73,8 @@ typedef enum {
     dataTypeStringLowHigh     /* String, low then high byte of each word  drvUser=STRING_LOW_HIGH*/
 } modbusDataType_t;
 
+struct modbusDrvUser_t;
+
 #define MAX_MODBUS_DATA_TYPES 15
 
 class epicsShareClass drvModbusAsyn : public asynPortDriver {
@@ -93,6 +95,7 @@ public:
 
    /* These functions are in the asynDrvUser interface */
     virtual asynStatus drvUserCreate(asynUser *pasynUser, const char *drvInfo, const char **pptypeName, size_t *psize);
+    virtual asynStatus drvUserDestroy(asynUser *pasynUser);
 
     /* These functions are in the asynUInt32Digital interface */
     virtual asynStatus writeUInt32Digital(asynUser *pasynUser, epicsUInt32 value, epicsUInt32 mask);
@@ -117,6 +120,7 @@ public:
     /* These are the methods that are new to this class */
     void readPoller();
     modbusDataType_t getDataType(asynUser *pasynUser);
+    int getStringLen(asynUser *pasynUser, size_t maxChars);
     asynStatus checkOffset(int offset);
     asynStatus checkModbusFunction(int *modbusFunction);
     asynStatus doModbusIO(int slave, int function, int start, epicsUInt16 *data, int len);
@@ -158,6 +162,7 @@ private:
     int modbusLength_;           /* Number of words or bits of Modbus data */
     bool absoluteAddressing_;    /* Address from asyn are absolute, rather than relative to modbusStartAddress */
     modbusDataType_t dataType_;  /* Data type */
+    modbusDrvUser_t *drvUser_;    /* Drv user structure */
     epicsUInt16 *data_;          /* Memory buffer */
     char modbusRequest_[MAX_MODBUS_FRAME_SIZE];      /* Modbus request message */
     char modbusReply_[MAX_MODBUS_FRAME_SIZE];        /* Modbus reply message */


### PR DESCRIPTION
This PR adds support for specifying an optional string length with the drvUser field using asynOctetRead and asynOctetWrite. It is useful when you don't want to use a waveform record in place of stringin/stringout.

The documentation is also updated to include function code 16 in the asynUInt32Digital html table.