### PR TITLE
Handle errors in drvModbusAsynConfigure

### DIFF
--- a/modbusApp/src/drvModbusAsyn.h
+++ b/modbusApp/src/drvModbusAsyn.h
@@ -145,6 +145,7 @@ protected:
  
 private:
     /* Our data */
+    bool initialized_;           /* If initialized successfully */
     char *octetPortName_;        /* asyn port name for the asyn octet port */
     char *plcType_;              /* String describing PLC type */
     bool isConnected_;            /* Connection status */


### PR DESCRIPTION
If an error is detected in `drvModbusAsynConfigure()` do not continue the initialization and disable the PVs that belong to the faulty port