### PR TITLE
An additional Data Type : FLOAT32_LEBE

### DIFF
--- a/modbusApp/src/drvModbusAsyn.cpp
+++ b/modbusApp/src/drvModbusAsyn.cpp
@@ -87,6 +87,7 @@ static modbusDataTypeStruct modbusDataTypes[MAX_MODBUS_DATA_TYPES] = {
     {dataTypeInt32LE,        MODBUS_INT32_LE_STRING},
     {dataTypeInt32BE,        MODBUS_INT32_BE_STRING},
     {dataTypeFloat32LE,      MODBUS_FLOAT32_LE_STRING},
+    {dataTypeFloat32LEBS,    MODBUS_FLOAT32_LEBS_STRING},
     {dataTypeFloat32BE,      MODBUS_FLOAT32_BE_STRING},
     {dataTypeFloat64LE,      MODBUS_FLOAT64_LE_STRING},
     {dataTypeFloat64BE,      MODBUS_FLOAT64_BE_STRING},
@@ -2018,6 +2019,7 @@ asynStatus drvModbusAsyn::readPlcInt(modbusDataType_t dataType, int offset, epic
             break;
 
         case dataTypeFloat32LE:
+        case dataTypeFloat32LEBS:
         case dataTypeFloat32BE:        
         case dataTypeFloat64LE:
         case dataTypeFloat64BE:        
@@ -2104,6 +2106,7 @@ asynStatus drvModbusAsyn::writePlcInt(modbusDataType_t dataType, int offset, epi
             break;
             
         case dataTypeFloat32LE:
+        case dataTypeFloat32LEBS:
         case dataTypeFloat32BE:        
         case dataTypeFloat64LE:
         case dataTypeFloat64BE:        
@@ -2147,8 +2150,15 @@ asynStatus drvModbusAsyn::readPlcFloat(modbusDataType_t dataType, int offset, ep
             status = readPlcInt(dataType, offset, &iValue, bufferLen);
             *output = (epicsFloat64)iValue;
             break;
-            
+
         case dataTypeFloat32LE:
+            uIntFloat.ui16[w32_0] = data_[offset];
+            uIntFloat.ui16[w32_1] = data_[offset+1];
+            *output = (epicsFloat64)uIntFloat.f32;
+            *bufferLen = 2;
+            break;
+
+        case dataTypeFloat32LEBS:
             uIntFloat.ui16[w32_0] = htons(data_[offset]);
             uIntFloat.ui16[w32_1] = htons(data_[offset+1]);
             *output = (epicsFloat64)uIntFloat.f32;
@@ -2222,7 +2232,14 @@ asynStatus drvModbusAsyn::writePlcFloat(modbusDataType_t dataType, int offset, e
             buffer[0] = uIntFloat.ui16[w32_0];
             buffer[1] = uIntFloat.ui16[w32_1];
             break;
-            
+
+        case dataTypeFloat32LEBS:
+            *bufferLen = 2;
+            uIntFloat.f32 = (epicsFloat32)value;
+            buffer[0] = htons(uIntFloat.ui16[w32_0]);
+            buffer[1] = htons(uIntFloat.ui16[w32_1]);
+            break;
+
         case dataTypeFloat32BE:
             *bufferLen = 2;
             uIntFloat.f32 = (epicsFloat32)value;

--- a/modbusApp/src/drvModbusAsyn.cpp
+++ b/modbusApp/src/drvModbusAsyn.cpp
@@ -2149,8 +2149,8 @@ asynStatus drvModbusAsyn::readPlcFloat(modbusDataType_t dataType, int offset, ep
             break;
             
         case dataTypeFloat32LE:
-            uIntFloat.ui16[w32_0] = data_[offset];
-            uIntFloat.ui16[w32_1] = data_[offset+1];
+            uIntFloat.ui16[w32_0] = htons(data_[offset]);
+            uIntFloat.ui16[w32_1] = htons(data_[offset+1]);
             *output = (epicsFloat64)uIntFloat.f32;
             *bufferLen = 2;
             break;

--- a/modbusApp/src/drvModbusAsyn.h
+++ b/modbusApp/src/drvModbusAsyn.h
@@ -45,6 +45,7 @@
 #define MODBUS_INT32_LE_STRING          "INT32_LE"
 #define MODBUS_INT32_BE_STRING          "INT32_BE"
 #define MODBUS_FLOAT32_LE_STRING        "FLOAT32_LE"
+#define MODBUS_FLOAT32_LEBS_STRING      "FLOAT32_LEBS"
 #define MODBUS_FLOAT32_BE_STRING        "FLOAT32_BE"
 #define MODBUS_FLOAT64_LE_STRING        "FLOAT64_LE"
 #define MODBUS_FLOAT64_BE_STRING        "FLOAT64_BE"
@@ -68,6 +69,7 @@ typedef enum {
     dataTypeInt32LE,          /* 32-bit integer little-endian  drvUser=INT32_LE */
     dataTypeInt32BE,          /* 32-bit integer big-endian     drvUser=INT32_BE */
     dataTypeFloat32LE,        /* 32-bit float little-endian    drvuser=FLOAT32_LE */
+    dataTypeFloat32LEBS,      /* 32-bit float little-endian, each 16-bit float byteswap drvuser=FLOAT32_LE_BS */
     dataTypeFloat32BE,        /* 32-bit float big-endian       drvUser=FLOAT32_BE */
     dataTypeFloat64LE,        /* 64-bit float little-endian    drvuser=FLOAT64_LE */
     dataTypeFloat64BE,        /* 64-bit float big-endian       drvUser=FLOAT64_BE */
@@ -83,7 +85,7 @@ typedef enum {
 
 struct modbusDrvUser_t;
 
-#define MAX_MODBUS_DATA_TYPES 19
+#define MAX_MODBUS_DATA_TYPES 20
 
 class epicsShareClass drvModbusAsyn : public asynPortDriver {
 public:


### PR DESCRIPTION
Hi,

I would like to discuss about this pull request, which I am not sure this approach is correct or not.  We can move this request to issues instead of this. 

I have the Modbus device, which has IEEE 32-bit floating point little endian according to its manual. So, the order of bytes is `1234`. With the latest `MODBUS` with `FLOAT32_LE` converts them to `3412`. However, what I need is `4321`. This pull request is the quick workaround to allow me to see the value correctly. So far "reading" is good enough. For more detail information is https://github.com/jeonghanlee/epics-ioc-NTI-E1W/blob/master/docs/DataFormat.md 

  
A few subjects I would like to discuss.  
  
- I select `FLOAT32_LEBS` not to change the exist data type.  
- I do not introduce `FLOAT32_BEBS`. 
- Even if I do not test it with the writing functionality, I add it into.  
- There are a few potential areas where I could not find, and we must update if you accept this proposal.  

 Please let me know what you think. 

@jeonghanlee