### PR TITLE
Improve dbd

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,10 @@
   defined `drvModbusAsyn.h`.  This is not very convenient, so the dataType argument was changed
   to a string.  It can now either be the enum value (for backwards compatibility) or one of the
   strings like `INT32_LE`.  The string comparison is case-insensitive.
+  NOTE: When using the iocsh shell this change is backwards compatible, because an unquoted
+  integer can be read as a string.  However, with the vxWorks shell it is not backwards
+  compatible, because string arguments must be quoted, so startup scripts will need to add quotes
+  around the dataType argument.
 - Improved the drvModbusAsyn::report() function to print the default dataType for the driver.
   The dataType is printed both as the integer enum value and as the corresponding string.
 - Changed the documentation and all example IOCs to set noProcessEos=0 in drvAsynIPPortConfigure()

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -283,10 +283,9 @@ that should be acted upon only if it is safe to do so.
 The architecture of the **modbus** module from the top-level down
 consists of the following 4 layers:
 
-1. `EPICS asyn device
-   support <https://epics-modules.github.io/master/asyn/R4-40/asynDriver.html#genericEpicsSupport>`__.
-   . This is the general purpose device support provided with
-   `asyn <http://www.aps.anl.gov/epics/modules/soft/asyn>`__ There is no
+1. `EPICS asyn device support <https://epics-modules.github.io/master/asyn/R4-40/asynDriver.html#genericEpicsSupport>`__.
+   This is the general purpose device support provided with
+   `asyn <https://github.com/epics-modules/asyn>`__ There is no
    special device support needed or provided with **modbus**.
 2. An EPICS asyn port driver that functions as a Modbus client. The
    **modbus** port driver communicates with EPICS device support (layer
@@ -525,7 +524,7 @@ commands:
    asynOctetSetInputEos(portName, addr, eos)
 
 Documentation on these commands can be found in the `asynDriver
-documentation <http://www.aps.anl.gov/epics/modules/soft/asyn/R4-29/asynDriver.html#DiagnosticAids>`__.
+documentation <https://epics-modules.github.io/master/asyn/R4-41/asynDriver.html#DiagnosticAids>`__.
 
 The following example creates an asyn local serial port driver called
 "Koyo1" on /dev/ttyS1. The default priority is used and the
@@ -1600,109 +1599,113 @@ ASCII however).
 
 ::
 
-   # Koyo1.cmd
-
-   dbLoadDatabase("../../dbd/modbus.dbd")
-   modbus_registerRecordDeviceDriver(pdbbase)
-
-   # Use the following commands for TCP/IP
-   #drvAsynIPPortConfigure(const char *portName, 
-   #                       const char *hostInfo,
-   #                       unsigned int priority, 
-   #                       int noAutoConnect,
-   #                       int noProcessEos);
-   drvAsynIPPortConfigure("Koyo1","164.54.160.158:502",0,0,0)
-   #modbusInterposeConfig(const char *portName, 
-   #                      modbusLinkType linkType,
-   #                      int timeoutMsec, 
-   #                      int writeDelayMsec)
-   modbusInterposeConfig("Koyo1",0,5000,0)
-
-   # Use the following commands for serial RTU or ASCII
-   #drvAsynSerialPortConfigure(const char *portName, 
-   #                           const char *ttyName,
-   #                           unsigned int priority, 
-   #                           int noAutoConnect,
-   #                           int noProcessEos);
-   #drvAsynSerialPortConfigure("Koyo1", "/dev/ttyS1", 0, 0, 0)
-   #asynSetOption("Koyo1",0,"baud","38400")
-   #asynSetOption("Koyo1",0,"parity","none")
-   #asynSetOption("Koyo1",0,"bits","8")
-   #asynSetOption("Koyo1",0,"stop","1")
-
-   # Use the following command for serial RTU
-   # Note: non-zero write delay (last parameter) may be needed.
-   #modbusInterposeConfig("Koyo1",1,1000,0)
-
-   # Use the following commands for serial ASCII
-   #asynOctetSetOutputEos("Koyo1",0,"\r\n")
-   #asynOctetSetInputEos("Koyo1",0,"\r\n")
-   # Note: non-zero write delay (last parameter) may be needed.
-   #modbusInterposeConfig("Koyo1",2,1000,0)
-
-   # NOTE: We use octal numbers for the start address and length (leading zeros)
-   #       to be consistent with the PLC nomenclature.  This is optional, decimal
-   #       numbers (no leading zero) or hex numbers can also be used.
-   #       In these examples we are using slave address 0 (number after "Koyo1").
-
-   # The DL205 has bit access to the Xn inputs at Modbus offset 4000 (octal)
-   # Read 32 bits (X0-X37).  Function code=2.
-   drvModbusAsynConfigure("K1_Xn_Bit",      "Koyo1", 0, 2,  04000, 040,    0,  100, "Koyo")
-
-   # The DL205 has word access to the Xn inputs at Modbus offset 40400 (octal)
-   # Read 8 words (128 bits).  Function code=3.
-   drvModbusAsynConfigure("K1_Xn_Word",     "Koyo1", 0, 3, 040400, 010,    0,  100, "Koyo")
-
-   # The DL205 has bit access to the Yn outputs at Modbus offset 4000 (octal)
-   # Read 32 bits (Y0-Y37).  Function code=1.
-   drvModbusAsynConfigure("K1_Yn_In_Bit",   "Koyo1", 0, 1,  04000, 040,    0,  100, "Koyo")
-
-   # The DL205 has bit access to the Yn outputs at Modbus offset 4000 (octal)
-   # Write 32 bits (Y0-Y37).  Function code=5.
-   drvModbusAsynConfigure("K1_Yn_Out_Bit",  "Koyo1", 0, 5,  04000, 040,    0,  1, "Koyo")
-
-   # The DL205 has word access to the Yn outputs at Modbus offset 40500 (octal)
-   # Read 8 words (128 bits).  Function code=3.
-   drvModbusAsynConfigure("K1_Yn_In_Word",  "Koyo1", 0, 3, 040500, 010,    0,  100, "Koyo")
-
-   # Write 8 words (128 bits).  Function code=6.
-   drvModbusAsynConfigure("K1_Yn_Out_Word", "Koyo1", 0, 6, 040500, 010,    0,  100, "Koyo")
-
-   # The DL205 has bit access to the Cn bits at Modbus offset 6000 (octal)
-   # Access 256 bits (C0-C377) as inputs.  Function code=1.
-   drvModbusAsynConfigure("K1_Cn_In_Bit",   "Koyo1", 0, 1,  06000, 0400,   0,  100, "Koyo")
-
-   # Access the same 256 bits (C0-C377) as outputs.  Function code=5.
-   drvModbusAsynConfigure("K1_Cn_Out_Bit",  "Koyo1", 0, 5,  06000, 0400,   0,  1,  "Koyo")
-
-   # Access the same 256 bits (C0-C377) as array outputs.  Function code=15.
-   drvModbusAsynConfigure("K1_Cn_Out_Bit_Array",  "Koyo1", 0, 15,  06000, 0400,   0,   1, "Koyo")
-
-   # The DL205 has word access to the Cn bits at Modbus offset 40600 (octal)
-   # We use the first 16 words (C0-C377) as inputs (256 bits).  Function code=3.
-   drvModbusAsynConfigure("K1_Cn_In_Word",  "Koyo1", 0, 3, 040600, 020,    0,  100, "Koyo")
-
-   # We access the same 16 words (C0-C377) as outputs (256 bits). Function code=6.
-   drvModbusAsynConfigure("K1_Cn_Out_Word", "Koyo1", 0, 6, 040600, 020,    0,  1,  "Koyo")
-
-   # We access the same 16 words (C0-C377) as array outputs (256 bits). Function code=16.
-   drvModbusAsynConfigure("K1_Cn_Out_Word_Array", "Koyo1", 0, 16, 040600, 020,    0,   1, "Koyo")
-
-   # Enable ASYN_TRACEIO_HEX on octet server
-   asynSetTraceIOMask("Koyo1",0,4)
-   # Enable ASYN_TRACE_ERROR and ASYN_TRACEIO_DRIVER on octet server
-   #asynSetTraceMask("Koyo1",0,9)
-
-   # Enable ASYN_TRACEIO_HEX on modbus server
-   asynSetTraceIOMask("K1_Yn_In_Bit",0,4)
-   # Enable all debugging on modbus server
-   #asynSetTraceMask("K1_Yn_In_Bit",0,255)
-   # Dump up to 512 bytes in asynTrace
-   asynSetTraceIOTruncateSize("K1_Yn_In_Bit",0,512)
-
-   dbLoadTemplate("Koyo1.substitutions")
-
-   iocInit
+    # Koyo1.cmd
+    
+    < envPaths
+    
+    dbLoadDatabase("../../dbd/modbusApp.dbd")
+    modbusApp_registerRecordDeviceDriver(pdbbase)
+    
+    # Use the following commands for TCP/IP
+    #drvAsynIPPortConfigure(const char *portName, 
+    #                       const char *hostInfo,
+    #                       unsigned int priority, 
+    #                       int noAutoConnect,
+    #                       int noProcessEos);
+    drvAsynIPPortConfigure("Koyo1","164.54.160.158:502",0,0,0)
+    asynSetOption("Koyo1",0, "disconnectOnReadTimeout", "Y")
+    m#modbusInterposeConfig(const char *portName, 
+    #                      modbusLinkType linkType,
+    #                      int timeoutMsec, 
+    #                      int writeDelayMsec)
+    modbusInterposeConfig("Koyo1",0,5000,0)
+    
+    # Use the following commands for serial RTU or ASCII
+    #drvAsynSerialPortConfigure(const char *portName, 
+    #                           const char *ttyName,
+    #                           unsigned int priority, 
+    #                           int noAutoConnect,
+    #                           int noProcessEos);
+    #drvAsynSerialPortConfigure("Koyo1", "/dev/ttyS1", 0, 0, 0)
+    #asynSetOption("Koyo1",0,"baud","38400")
+    #asynSetOption("Koyo1",0,"parity","none")
+    #asynSetOption("Koyo1",0,"bits","8")
+    #asynSetOption("Koyo1",0,"stop","1")
+    
+    # Use the following command for serial RTU
+    # Note: non-zero write delay (last parameter) may be needed.
+    #modbusInterposeConfig("Koyo1",1,1000,0)
+    
+    # Use the following commands for serial ASCII
+    #asynOctetSetOutputEos("Koyo1",0,"\r\n")
+    #asynOctetSetInputEos("Koyo1",0,"\r\n")
+    # Note: non-zero write delay (last parameter) may be needed.
+    #modbusInterposeConfig("Koyo1",2,1000,0)
+    
+    # NOTE: We use octal numbers for the start address and length (leading zeros)
+    #       to be consistent with the PLC nomenclature.  This is optional, decimal
+    #       numbers (no leading zero) or hex numbers can also be used.
+    #       In these examples we are using slave address 0 (number after "Koyo1").
+    
+    # The DL205 has bit access to the Xn inputs at Modbus offset 4000 (octal)
+    # Read 32 bits (X0-X37).  Function code=2.
+    drvModbusAsynConfigure("K1_Xn_Bit",      "Koyo1", 0, 2,  04000, 040,    0,  100, "Koyo")
+    
+    # The DL205 has word access to the Xn inputs at Modbus offset 40400 (octal)
+    # Read 8 words (128 bits).  Function code=3.
+    drvModbusAsynConfigure("K1_Xn_Word",     "Koyo1", 0, 3, 040400, 010,    0,  100, "Koyo")
+    
+    # The DL205 has bit access to the Yn outputs at Modbus offset 4000 (octal)
+    # Read 32 bits (Y0-Y37).  Function code=1.
+    drvModbusAsynConfigure("K1_Yn_In_Bit",   "Koyo1", 0, 1,  04000, 040,    0,  100, "Koyo")
+    
+    # The DL205 has bit access to the Yn outputs at Modbus offset 4000 (octal)
+    # Write 32 bits (Y0-Y37).  Function code=5.
+    drvModbusAsynConfigure("K1_Yn_Out_Bit",  "Koyo1", 0, 5,  04000, 040,    0,  1, "Koyo")
+    
+    # The DL205 has word access to the Yn outputs at Modbus offset 40500 (octal)
+    # Read 8 words (128 bits).  Function code=3.
+    drvModbusAsynConfigure("K1_Yn_In_Word",  "Koyo1", 0, 3, 040500, 010,    0,  100, "Koyo")
+    
+    # Write 8 words (128 bits).  Function code=6.
+    drvModbusAsynConfigure("K1_Yn_Out_Word", "Koyo1", 0, 6, 040500, 010,    0,  100, "Koyo")
+    
+    # The DL205 has bit access to the Cn bits at Modbus offset 6000 (octal)
+    # Access 256 bits (C0-C377) as inputs.  Function code=1.
+    drvModbusAsynConfigure("K1_Cn_In_Bit",   "Koyo1", 0, 1,  06000, 0400,   0,  100, "Koyo")
+    
+    # Access the same 256 bits (C0-C377) as outputs.  Function code=5.
+    drvModbusAsynConfigure("K1_Cn_Out_Bit",  "Koyo1", 0, 5,  06000, 0400,   0,  1,  "Koyo")
+    
+    # Access the same 256 bits (C0-C377) as array outputs.  Function code=15.
+    drvModbusAsynConfigure("K1_Cn_Out_Bit_Array",  "Koyo1", 0, 15,  06000, 0400,   0,   1, "Koyo")
+    
+    # The DL205 has word access to the Cn bits at Modbus offset 40600 (octal)
+    # We use the first 16 words (C0-C377) as inputs (256 bits).  Function code=3.
+    drvModbusAsynConfigure("K1_Cn_In_Word",  "Koyo1", 0, 3, 040600, 020,    0,  100, "Koyo")
+    
+    # We access the same 16 words (C0-C377) as outputs (256 bits). Function code=6.
+    drvModbusAsynConfigure("K1_Cn_Out_Word", "Koyo1", 0, 6, 040600, 020,    0,  1,  "Koyo")
+    
+    # We access the same 16 words (C0-C377) as array outputs (256 bits). Function code=16.
+    drvModbusAsynConfigure("K1_Cn_Out_Word_Array", "Koyo1", 0, 16, 040600, 020,    0,   1, "Koyo")
+    
+    # Enable ASYN_TRACEIO_HEX on octet server
+    asynSetTraceIOMask("Koyo1",0,4)
+    # Enable ASYN_TRACE_ERROR and ASYN_TRACEIO_DRIVER on octet server
+    #asynSetTraceMask("Koyo1",0,9)
+    
+    # Enable ASYN_TRACEIO_HEX on modbus server
+    asynSetTraceIOMask("K1_Yn_In_Bit",0,4)
+    # Enable all debugging on modbus server
+    #asynSetTraceMask("K1_Yn_In_Bit",0,255)
+    # Dump up to 512 bytes in asynTrace
+    asynSetTraceIOTruncateSize("K1_Yn_In_Bit",0,512)
+    
+    dbLoadTemplate("Koyo1.substitutions")
+    
+    iocInit
+    
 
 Note that this example is designed for testing and demonstration
 purposes, not as a realistic example of how **modbus** would normally be

--- a/iocBoot/iocTest/Koyo1.cmd
+++ b/iocBoot/iocTest/Koyo1.cmd
@@ -2,8 +2,8 @@
 
 < envPaths
 
-dbLoadDatabase("../../dbd/modbus.dbd")
-modbus_registerRecordDeviceDriver(pdbbase)
+dbLoadDatabase("../../dbd/modbusApp.dbd")
+modbusApp_registerRecordDeviceDriver(pdbbase)
 
 # Use the following commands for TCP/IP
 #drvAsynIPPortConfigure(const char *portName, 

--- a/iocBoot/iocTest/Koyo2.cmd
+++ b/iocBoot/iocTest/Koyo2.cmd
@@ -1,7 +1,7 @@
 # Koyo2.cmd
 
-dbLoadDatabase("../../dbd/modbus.dbd")
-modbus_registerRecordDeviceDriver(pdbbase)
+dbLoadDatabase("../../dbd/modbusApp.dbd")
+modbusApp_registerRecordDeviceDriver(pdbbase)
 
 # Use the following commands for TCP/IP
 #drvAsynIPPortConfigure(const char *portName,

--- a/iocBoot/iocTest/Koyo_Sim1.cmd
+++ b/iocBoot/iocTest/Koyo_Sim1.cmd
@@ -8,8 +8,8 @@
 
 < envPaths
 
-dbLoadDatabase("../../dbd/modbus.dbd")
-modbus_registerRecordDeviceDriver(pdbbase)
+dbLoadDatabase("../../dbd/modbusApp.dbd")
+modbusApp_registerRecordDeviceDriver(pdbbase)
 
 # Use the following commands for TCP/IP
 #drvAsynIPPortConfigure(const char *portName, 

--- a/iocBoot/iocTest/array_test.cmd
+++ b/iocBoot/iocTest/array_test.cmd
@@ -1,7 +1,7 @@
 < envPaths
 
-dbLoadDatabase("../../dbd/modbus.dbd")
-modbus_registerRecordDeviceDriver(pdbbase)
+dbLoadDatabase("../../dbd/modbusApp.dbd")
+modbusApp_registerRecordDeviceDriver(pdbbase)
 
 # Use the following commands for TCP/IP
 #drvAsynIPPortConfigure(const char *portName,

--- a/iocBoot/iocTest/sim2.cmd
+++ b/iocBoot/iocTest/sim2.cmd
@@ -1,7 +1,7 @@
 # simulator.cmd
 
-dbLoadDatabase("../../dbd/modbus.dbd")
-modbus_registerRecordDeviceDriver(pdbbase)
+dbLoadDatabase("../../dbd/modbusApp.dbd")
+modbusApp_registerRecordDeviceDriver(pdbbase)
 
 # Use the following commands for TCP/IP
 #drvAsynIPPortConfigure(const char *portName,

--- a/iocBoot/iocTest/sim3.cmd
+++ b/iocBoot/iocTest/sim3.cmd
@@ -2,8 +2,8 @@
 
 <envPaths
 
-dbLoadDatabase("../../dbd/modbus.dbd")
-modbus_registerRecordDeviceDriver(pdbbase)
+dbLoadDatabase("../../dbd/modbusApp.dbd")
+modbusApp_registerRecordDeviceDriver(pdbbase)
 
 # Use the following commands for TCP/IP
 #drvAsynIPPortConfigure(const char *portName,

--- a/iocBoot/iocTest/sim4.cmd
+++ b/iocBoot/iocTest/sim4.cmd
@@ -2,8 +2,8 @@
 
 <envPaths
 
-dbLoadDatabase("../../dbd/modbus.dbd")
-modbus_registerRecordDeviceDriver(pdbbase)
+dbLoadDatabase("../../dbd/modbusApp.dbd")
+modbusApp_registerRecordDeviceDriver(pdbbase)
 
 # Use the following commands for TCP/IP
 #drvAsynIPPortConfigure(const char *portName,

--- a/iocBoot/iocTest/sim5.cmd
+++ b/iocBoot/iocTest/sim5.cmd
@@ -3,8 +3,8 @@
 
 < envPaths
 
-dbLoadDatabase("../../dbd/modbus.dbd")
-modbus_registerRecordDeviceDriver(pdbbase)
+dbLoadDatabase("../../dbd/modbusApp.dbd")
+modbusApp_registerRecordDeviceDriver(pdbbase)
 
 # Use the following commands for TCP/IP
 #drvAsynIPPortConfigure(const char *portName,

--- a/iocBoot/iocTest/sim6.cmd
+++ b/iocBoot/iocTest/sim6.cmd
@@ -3,8 +3,8 @@
 
 < envPaths
 
-dbLoadDatabase("../../dbd/modbus.dbd")
-modbus_registerRecordDeviceDriver(pdbbase)
+dbLoadDatabase("../../dbd/modbusApp.dbd")
+modbusApp_registerRecordDeviceDriver(pdbbase)
 
 # Use the following commands for TCP/IP
 #drvAsynIPPortConfigure(const char *portName,

--- a/iocBoot/iocTest/testAbsoluteAddress.cmd
+++ b/iocBoot/iocTest/testAbsoluteAddress.cmd
@@ -8,8 +8,8 @@
 # correctly by the Modbus slave.
 # The medm file testDataTypes.adl is used to change the output records and display the readback records.
 
-dbLoadDatabase("../../dbd/modbus.dbd")
-modbus_registerRecordDeviceDriver(pdbbase)
+dbLoadDatabase("../../dbd/modbusApp.dbd")
+modbusApp_registerRecordDeviceDriver(pdbbase)
 
 # Use the following commands for TCP/IP
 #drvAsynIPPortConfigure(const char *portName,

--- a/iocBoot/iocTest/testDataTypes.cmd
+++ b/iocBoot/iocTest/testDataTypes.cmd
@@ -8,8 +8,8 @@
 # correctly by the Modbus slave.
 # The medm file testDataTypes.adl is used to change the output records and display the readback records.
 
-dbLoadDatabase("../../dbd/modbus.dbd")
-modbus_registerRecordDeviceDriver(pdbbase)
+dbLoadDatabase("../../dbd/modbusApp.dbd")
+modbusApp_registerRecordDeviceDriver(pdbbase)
 
 # Use the following commands for TCP/IP
 #drvAsynIPPortConfigure(const char *portName,

--- a/modbusApp/src/Makefile
+++ b/modbusApp/src/Makefile
@@ -10,7 +10,7 @@ include $(TOP)/configure/CONFIG
 # Build an IOC support library
 
 # <name>.dbd will be created from <name>Include.dbd
-DBD += modbus.dbd
+DBD += modbusApp.dbd
 DBD += modbusSupport.dbd
 
 INC += drvModbusAsyn.h
@@ -33,9 +33,13 @@ LIB_SYS_LIBS_WIN32 += ws2_32
 # build an ioc application
 
 PROD_IOC += modbusApp
+modbusApp_DBD += base.dbd
+modbusApp_DBD += asyn.dbd drvAsynIPPort.dbd drvAsynSerialPort.dbd
+modbusApp_DBD += modbusSupport.dbd
+
 # <name>_registerRecordDeviceDriver.cpp will be created from <name>.dbd
-modbusApp_SRCS_DEFAULT += modbus_registerRecordDeviceDriver.cpp modbusMain.cpp
-modbusApp_SRCS_vxWorks += modbus_registerRecordDeviceDriver.cpp
+modbusApp_SRCS_DEFAULT += modbusApp_registerRecordDeviceDriver.cpp modbusMain.cpp
+modbusApp_SRCS_vxWorks += modbusApp_registerRecordDeviceDriver.cpp
 
 PROD_IOC += testClient
 testClient_SRCS += testClient.cpp

--- a/modbusApp/src/modbusInclude.dbd
+++ b/modbusApp/src/modbusInclude.dbd
@@ -1,7 +1,0 @@
-include "base.dbd"
-include "asyn.dbd"
-include "drvAsynIPPort.dbd"
-include "drvAsynSerialPort.dbd"
-include "modbusSupport.dbd"
-registrar(testModbusSyncIORegister)
-


### PR DESCRIPTION
This fixes #26.

Changes:
- Renamed modbus.dbd to modbusApp.dbd.  I think this is clearer, indicating that it is the example application.
- Build modbusApp.dbd in the Makefile, delete modbusInclude.dbd.
- Change all example startup scripts to replace modbus.dbd with modbusApp.dbd and modbus_registerRecordDeviceDriver with modbusApp_registerRecordDeviceDriver

