### PR TITLE
Docs: switch sphinx plugin (m2r to m2r2)

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 sphinx==1.8.5
 sphinx-bootstrap-theme
-m2r
+m2r2
 sphinx-multibuild
 breathe

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,7 +42,7 @@ version = '-'.join(release.split('-')[0:2])
 extensions = [
     'sphinx.ext.todo',
 #    'sphinx.ext.githubpages',
-    'm2r',
+    'm2r2',
 #    'breathe',
 #    'linuxdoc.rstFlatTable'
 ]


### PR DESCRIPTION
m2r seems abandoned and stopped working with newer Sphinx
(see also https://github.com/sphinx-doc/sphinx/issues/8395)