### PR TITLE
When using absolute addressing, only read the minimal required words

### DIFF
--- a/modbusApp/src/drvModbusAsyn.cpp
+++ b/modbusApp/src/drvModbusAsyn.cpp
@@ -517,7 +517,7 @@ asynStatus drvModbusAsyn::readUInt32Digital(asynUser *pasynUser, epicsUInt32 *va
             /* If absolute addressing then there is no poller running */
             if (checkModbusFunction(&modbusFunction)) return asynError;
             ioStatus_ = doModbusIO(modbusSlave_, modbusFunction,
-                                   offset, data_, modbusLength_);
+                                   offset, data_, std::min(1, modbusLength_));
             if (ioStatus_ != asynSuccess) return(ioStatus_);
             offset = 0;
             readOnceDone_ = true;
@@ -667,7 +667,7 @@ asynStatus drvModbusAsyn::readInt32 (asynUser *pasynUser, epicsInt32 *value)
             /* If absolute addressing then there is no poller running */
             if (checkModbusFunction(&modbusFunction)) return asynError;
             ioStatus_ = doModbusIO(modbusSlave_, modbusFunction,
-                                        offset, data_, modbusLength_);
+                                        offset, data_, std::min(2, modbusLength_));
             if (ioStatus_ != asynSuccess) return(ioStatus_);
             offset = 0;
             readOnceDone_ = true;
@@ -828,7 +828,7 @@ asynStatus drvModbusAsyn::readInt64 (asynUser *pasynUser, epicsInt64 *value)
             /* If absolute addressing then there is no poller running */
             if (checkModbusFunction(&modbusFunction)) return asynError;
             ioStatus_ = doModbusIO(modbusSlave_, modbusFunction,
-                                   offset, data_, modbusLength_);
+                                   offset, data_, std::min(4, modbusLength_));
             if (ioStatus_ != asynSuccess) return(ioStatus_);
             offset = 0;
             readOnceDone_ = true;
@@ -974,7 +974,7 @@ asynStatus drvModbusAsyn::readFloat64 (asynUser *pasynUser, epicsFloat64 *value)
             /* If absolute addressing then there is no poller running */
             if (checkModbusFunction(&modbusFunction)) return asynError;
             ioStatus_ = doModbusIO(modbusSlave_, modbusFunction,
-                                        offset, data_, modbusLength_);
+                                        offset, data_, std::min(4, modbusLength_));
             if (ioStatus_ != asynSuccess) return(ioStatus_);
             offset = 0;
             readOnceDone_ = true;
@@ -1117,7 +1117,7 @@ asynStatus drvModbusAsyn::readInt32Array (asynUser *pasynUser, epicsInt32 *data,
             /* If absolute addressing then there is no poller running */
             if (checkModbusFunction(&modbusFunction)) return asynError;
             ioStatus_ = doModbusIO(modbusSlave_, modbusFunction,
-                                   offset, data_, modbusLength_);
+                                   offset, data_, std::min(maxChans, static_cast<size_t>(modbusLength_)));
             if (ioStatus_ != asynSuccess) return(ioStatus_);
             offset = 0;
         } else {
@@ -1287,7 +1287,7 @@ asynStatus drvModbusAsyn::readOctet(asynUser *pasynUser, char *data, size_t maxC
             /* If absolute addressing then there is no poller running */
             if (checkModbusFunction(&modbusFunction)) return asynError;
             ioStatus_ = doModbusIO(modbusSlave_, modbusFunction,
-                                   offset, data_, modbusLength_);
+                                   offset, data_, std::min(maxChars, static_cast<size_t>(modbusLength_)));
             if (ioStatus_ != asynSuccess) return(ioStatus_);
             offset = 0;
         } else {


### PR DESCRIPTION
This changes the read function to only read the minimum required words when using absolute addressing. They will never read more than modbusLength words.

Takes this as a proof of concept, I'm not sure if this works in all situations.

Fixes #33