### PR TITLE
Add a data type UINT16_BS  : byte swapped in unsigned 16-bit integers

### DIFF
--- a/docs/source/creating_driver.rst
+++ b/docs/source/creating_driver.rst
@@ -279,6 +279,9 @@ treats the registers as unsigned 16-bit integers.
       by Koyo PLCs for numbers such as ADC conversions.
   * - UINT16
     - Unsigned 16-bit binary integers.
+  * - UINT16_BS
+    - Unsigned 16-bit binary integers.The high-order 8-bit byte and low-order 8-bit byte 
+      within the 16-bit register are swapped.
   * - INT32_LE
     - 32-bit integers, little endian (least significant word at Modbus address N, most
       significant word at Modbus address N+1).

--- a/modbusApp/src/drvModbusAsyn.cpp
+++ b/modbusApp/src/drvModbusAsyn.cpp
@@ -90,6 +90,7 @@ static modbusDataTypeStruct modbusDataTypes[MAX_MODBUS_DATA_TYPES] = {
     {dataTypeBCDUnsigned,    MODBUS_BCD_UNSIGNED_STRING},
     {dataTypeBCDSigned,      MODBUS_BCD_SIGNED_STRING},
     {dataTypeUInt16,         MODBUS_UINT16_STRING},
+    {dataTypeUInt16BS,       MODBUS_UINT16_BS_STRING},
     {dataTypeInt32LE,        MODBUS_INT32_LE_STRING},
     {dataTypeInt32LEBS,      MODBUS_INT32_LE_BS_STRING},
     {dataTypeInt32BE,        MODBUS_INT32_BE_STRING},
@@ -2454,6 +2455,10 @@ asynStatus drvModbusAsyn::readPlcInt64(modbusDataType_t dataType, int offset, ep
             i64Result = ui16Value;
             break;
 
+        case dataTypeUInt16BS:
+            i64Result = bswap16(ui16Value);
+            break;
+
         case dataTypeInt16SM:
             i64Result = ui16Value;
             if (i64Result & signMask) {
@@ -2616,6 +2621,10 @@ asynStatus drvModbusAsyn::writePlcInt64(modbusDataType_t dataType, int offset, e
         case dataTypeUInt16:
             buffer[0] = (epicsUInt16)value;
             break;
+        
+        case dataTypeUInt16BS:
+            buffer[0] = bswap16((epicsUInt16)value);
+            break; 
 
         case dataTypeInt16SM:
             ui16Value = (epicsUInt16)value;
@@ -2767,6 +2776,7 @@ asynStatus drvModbusAsyn::readPlcFloat(modbusDataType_t dataType, int offset, ep
 
     switch (dataType) {
         case dataTypeUInt16:
+        case dataTypeUInt16BS:
         case dataTypeInt16SM:
         case dataTypeBCDSigned:
         case dataTypeBCDUnsigned:
@@ -2893,6 +2903,7 @@ asynStatus drvModbusAsyn::writePlcFloat(modbusDataType_t dataType, int offset, e
 
     switch (dataType) {
         case dataTypeUInt16:
+        case dataTypeUInt16BS: 
         case dataTypeInt16SM:
         case dataTypeBCDSigned:
         case dataTypeBCDUnsigned:

--- a/modbusApp/src/drvModbusAsyn.h
+++ b/modbusApp/src/drvModbusAsyn.h
@@ -42,6 +42,7 @@
 #define MODBUS_BCD_UNSIGNED_STRING      "BCD_UNSIGNED"
 #define MODBUS_BCD_SIGNED_STRING        "BCD_SIGNED"
 #define MODBUS_UINT16_STRING            "UINT16"
+#define MODBUS_UINT16_BS_STRING         "UINT16_BS"
 #define MODBUS_INT32_LE_STRING          "INT32_LE"
 #define MODBUS_INT32_LE_BS_STRING       "INT32_LE_BS"
 #define MODBUS_INT32_BE_STRING          "INT32_BE"
@@ -83,6 +84,7 @@ typedef enum {
     dataTypeBCDUnsigned,
     dataTypeBCDSigned,
     dataTypeUInt16,
+    dataTypeUInt16BS,
     dataTypeInt32LE,
     dataTypeInt32LEBS,
     dataTypeInt32BE,


### PR DESCRIPTION
The PLC we used stores a word as an unsigned 16-bit integer. But bytes with this 16-bit register are swapped. This data type is not supported by Modbus. Therefore, I modified the source code to support 16-bit unsigned intergers with swapped bytes within a word. I add a new data type called UINT16_BS.