### PR TITLE
Add DESC fields and macros to template files with empty default values

### DIFF
--- a/modbusApp/Db/ai.template
+++ b/modbusApp/Db/ai.template
@@ -1,6 +1,7 @@
 # ai record template for register inputs
 record(ai, "$(P)$(R)") {
     field(DTYP,"asynInt32")
+    field(DESC, "$(DESC=)")
     field(INP,"@asynMask($(PORT) $(OFFSET) $(BITS))MODBUS_DATA")
     field(LINR,"LINEAR")
     field(EGUL,"$(EGUL)")

--- a/modbusApp/Db/aiFloat64.template
+++ b/modbusApp/Db/aiFloat64.template
@@ -1,6 +1,7 @@
 # ai record template for register inputs
 record(ai, "$(P)$(R)") {
     field(DTYP,"asynFloat64")
+    field(DESC, "$(DESC=)")
     field(INP,"@asyn($(PORT) $(OFFSET))$(DATA_TYPE)")
     field(HOPR,"$(HOPR=0)")
     field(LOPR,"$(LOPR=0)")

--- a/modbusApp/Db/ai_average.template
+++ b/modbusApp/Db/ai_average.template
@@ -1,6 +1,7 @@
 # ai record template for register inputs
 record(ai, "$(P)$(R)") {
     field(DTYP,"asynInt32Average")
+    field(DESC, "$(DESC=)")
     field(INP,"@asynMask($(PORT) $(OFFSET) $(BITS))MODBUS_DATA")
     field(LINR,"LINEAR")
     field(EGUL,"$(EGUL=0)")

--- a/modbusApp/Db/ao.template
+++ b/modbusApp/Db/ao.template
@@ -1,6 +1,7 @@
 # ao record template for register outputs
 record(ao, "$(P)$(R)") {
     field(DTYP,"asynInt32")
+    field(DESC, "$(DESC=)")
     field(OUT,"@asynMask($(PORT) $(OFFSET) $(BITS))MODBUS_DATA")
     field(LINR,"LINEAR")
     field(EGUL,"$(EGUL)")

--- a/modbusApp/Db/aoFloat64.template
+++ b/modbusApp/Db/aoFloat64.template
@@ -1,6 +1,7 @@
 # ao record template for register outputs
 record(ao, "$(P)$(R)") {
     field(DTYP,"asynFloat64")
+    field(DESC, "$(DESC=)")
     field(OUT,"@asyn($(PORT) $(OFFSET))$(DATA_TYPE)")
     field(HOPR,"$(HOPR=0)")
     field(LOPR,"$(LOPR=0)")

--- a/modbusApp/Db/asynRecord.template
+++ b/modbusApp/Db/asynRecord.template
@@ -1,6 +1,7 @@
 record(asyn,"$(P)$(R)")
 {
     field(DTYP,"asynRecordDevice")
+    field(DESC, "$(DESC=)")
     field(PORT,"$(PORT)")
     field(ADDR,"$(ADDR)")
     field(TMOD,"$(TMOD)")

--- a/modbusApp/Db/bi_bit.template
+++ b/modbusApp/Db/bi_bit.template
@@ -1,6 +1,7 @@
 # bi record template for register inputs
 record(bi,"$(P)$(R)") {
     field(DTYP,"asynUInt32Digital")
+    field(DESC, "$(DESC=)")
     field(INP,"@asynMask($(PORT) $(OFFSET) 0x1)")
     field(SCAN,"$(SCAN)")
     field(ZNAM,"$(ZNAM)")

--- a/modbusApp/Db/bi_word.template
+++ b/modbusApp/Db/bi_word.template
@@ -1,6 +1,7 @@
 # bi record template for register inputs
 record(bi,"$(P)$(R)") {
     field(DTYP,"asynUInt32Digital")
+    field(DESC, "$(DESC=)")
     field(INP,"@asynMask($(PORT) $(OFFSET) $(MASK))")
     field(SCAN,"$(SCAN)")
     field(ZNAM,"$(ZNAM)")

--- a/modbusApp/Db/bo_bit.template
+++ b/modbusApp/Db/bo_bit.template
@@ -1,6 +1,7 @@
 # bo record template for register outputs
 record(bo,"$(P)$(R)") {
     field(DTYP,"asynUInt32Digital")
+    field(DESC, "$(DESC=)")
     field(OUT,"@asynMask($(PORT) $(OFFSET) 0x1)")
     field(ZNAM,"$(ZNAM)")
     field(ONAM,"$(ONAM)")

--- a/modbusApp/Db/bo_word.template
+++ b/modbusApp/Db/bo_word.template
@@ -1,6 +1,7 @@
 # bo record template for register outputs
 record(bo,"$(P)$(R)") {
     field(DTYP,"asynUInt32Digital")
+    field(DESC, "$(DESC=)")
     field(OUT,"@asynMask($(PORT) $(OFFSET) $(MASK))")
     field(ZNAM,"$(ZNAM)")
     field(ONAM,"$(ONAM)")

--- a/modbusApp/Db/floatarray_in.template
+++ b/modbusApp/Db/floatarray_in.template
@@ -1,5 +1,6 @@
 record(waveform,"$(P)$(R)") {
     field(DTYP,"asynFloat64ArrayIn")
+    field(DESC, "$(DESC=)")
     field(INP,"@asyn($(PORT) $(OFFSET=0))MODBUS_DATA")
     field(SCAN,"$(SCAN)")
     field(FTVL,"DOUBLE")

--- a/modbusApp/Db/floatarray_out.template
+++ b/modbusApp/Db/floatarray_out.template
@@ -1,5 +1,6 @@
 record(waveform,"$(P)$(R)") {
     field(DTYP,"asynFloat64ArrayOut")
+    field(DESC, "$(DESC=)")
     field(INP,"@asyn($(PORT) $(OFFSET=0))MODBUS_DATA")
     field(FTVL,"DOUBLE")
     field(NELM,"$(NELM)")

--- a/modbusApp/Db/int64in.template
+++ b/modbusApp/Db/int64in.template
@@ -1,6 +1,7 @@
 # int64in record template for register inputs
 record(int64in,"$(P)$(R)") {
     field(DTYP,"asynInt64")
+    field(DESC, "$(DESC=)")
     field(INP,"@asyn($(PORT) $(OFFSET))$(DATA_TYPE)")
     field(SCAN, "$(SCAN)")
 }

--- a/modbusApp/Db/int64out.template
+++ b/modbusApp/Db/int64out.template
@@ -1,5 +1,6 @@
 # int64out record template for register inputs
 record(int64out,"$(P)$(R)") {
     field(DTYP,"asynInt64")
+    field(DESC, "$(DESC=)")
     field(OUT,"@asyn($(PORT) $(OFFSET))$(DATA_TYPE)")
 }

--- a/modbusApp/Db/intarray_in.template
+++ b/modbusApp/Db/intarray_in.template
@@ -1,5 +1,6 @@
 record(waveform,"$(P)$(R)") {
     field(DTYP,"asynInt32ArrayIn")
+    field(DESC, "$(DESC=)")
     field(INP,"@asyn($(PORT) $(OFFSET=0))MODBUS_DATA")
     field(SCAN,"$(SCAN)")
     field(FTVL,"LONG")

--- a/modbusApp/Db/intarray_out.template
+++ b/modbusApp/Db/intarray_out.template
@@ -1,5 +1,6 @@
 record(waveform,"$(P)$(R)") {
     field(DTYP,"asynInt32ArrayOut")
+    field(DESC, "$(DESC=)")
     field(INP,"@asyn($(PORT) $(OFFSET=0))MODBUS_DATA")
     field(FTVL,"LONG")
     field(NELM,"$(NELM)")

--- a/modbusApp/Db/longin.template
+++ b/modbusApp/Db/longin.template
@@ -1,6 +1,7 @@
 # longin record template for register inputs
 record(longin,"$(P)$(R)") {
     field(DTYP,"asynUInt32Digital")
+    field(DESC, "$(DESC=)")
     field(INP,"@asynMask($(PORT) $(OFFSET) 0xFFFF)")
     field(SCAN,"$(SCAN)")
 }

--- a/modbusApp/Db/longinInt32.template
+++ b/modbusApp/Db/longinInt32.template
@@ -1,6 +1,7 @@
 # longin record template for register inputs
 record(longin,"$(P)$(R)") {
     field(DTYP,"asynInt32")
+    field(DESC, "$(DESC=)")
     field(INP,"@asyn($(PORT) $(OFFSET))$(DATA_TYPE)")
     field(SCAN, "$(SCAN)")
 }

--- a/modbusApp/Db/longout.template
+++ b/modbusApp/Db/longout.template
@@ -1,5 +1,6 @@
 # longout record template for register inputs
 record(longout,"$(P)$(R)") {
     field(DTYP,"asynUInt32Digital")
+    field(DESC, "$(DESC=)")
     field(OUT,"@asynMask($(PORT) $(OFFSET) 0xFFFF)")
 }

--- a/modbusApp/Db/longoutInt32.template
+++ b/modbusApp/Db/longoutInt32.template
@@ -1,6 +1,7 @@
 # longout record template for register inputs
 record(longout,"$(P)$(R)") {
     field(DTYP,"asynInt32")
+    field(DESC, "$(DESC=)")
     field(OUT,"@asyn($(PORT) $(OFFSET))$(DATA_TYPE)")
     field(PINI,"$(PINI=NO)")
 }

--- a/modbusApp/Db/mbbiDirect.template
+++ b/modbusApp/Db/mbbiDirect.template
@@ -1,6 +1,7 @@
 # mbbiDirect record template for register inputs
 record(mbbiDirect,"$(P)$(R)") {
     field(DTYP,"asynUInt32Digital")
+    field(DESC, "$(DESC=)")
     field(INP,"@asynMask($(PORT) $(OFFSET) $(MASK))")
     field(SCAN,"$(SCAN)")
 }

--- a/modbusApp/Db/mbboDirect.template
+++ b/modbusApp/Db/mbboDirect.template
@@ -1,5 +1,6 @@
 # mbboDirect record template for register outputs
 record(mbboDirect,"$(P)$(R)") {
     field(DTYP,"asynUInt32Digital")
+    field(DESC, "$(DESC=)")
     field(OUT,"@asynMask($(PORT) $(OFFSET) $(MASK))")
 }

--- a/modbusApp/Db/poll_delay.template
+++ b/modbusApp/Db/poll_delay.template
@@ -1,6 +1,7 @@
 # ao record template for poll delay
 record(ao,"$(P)$(R)") {
     field(DTYP,"asynFloat64")
+    field(DESC, "$(DESC=)")
     field(PREC,"3")
     field(OUT,"@asyn($(PORT))POLL_DELAY")
 }

--- a/modbusApp/Db/poll_trigger.template
+++ b/modbusApp/Db/poll_trigger.template
@@ -1,5 +1,6 @@
 # ao record template for poll delay
 record(bo,"$(P)$(R)") {
     field(DTYP,"asynInt32")
+    field(DESC, "$(DESC=)")
     field(OUT,"@asyn($(PORT))MODBUS_READ")
 }

--- a/modbusApp/Db/stringWaveformIn.template
+++ b/modbusApp/Db/stringWaveformIn.template
@@ -1,5 +1,6 @@
 record(waveform,"$(P)$(R)") {
     field(DTYP,"asynOctetRead")
+    field(DESC, "$(DESC=)")
     field(INP,"@asyn($(PORT) $(OFFSET=0))$(DATA_TYPE)")
     field(SCAN,"$(SCAN)")
     field(FTVL,"CHAR")

--- a/modbusApp/Db/stringWaveformOut.template
+++ b/modbusApp/Db/stringWaveformOut.template
@@ -1,5 +1,6 @@
 record(waveform,"$(P)$(R)") {
     field(DTYP,"asynOctetWrite")
+    field(DESC, "$(DESC=)")
     field(INP,"@asyn($(PORT) $(OFFSET=0))$(DATA_TYPE)")
     field(FTVL,"CHAR")
     field(NELM,"$(NELM)")

--- a/modbusApp/Db/stringin.template
+++ b/modbusApp/Db/stringin.template
@@ -1,6 +1,7 @@
 # longin record template for register inputs
 record(stringin,"$(P)$(R)") {
     field(DTYP,"asynOctetRead")
+    field(DESC, "$(DESC=)")
     field(INP,"@asyn($(PORT) $(OFFSET))$(DATA_TYPE)")
     field(SCAN,"$(SCAN)")
 }

--- a/modbusApp/Db/stringout.template
+++ b/modbusApp/Db/stringout.template
@@ -1,6 +1,7 @@
 # stringout record template 
 record(stringout,"$(P)$(R)") {
     field(DTYP,"asynOctetWrite")
+    field(DESC, "$(DESC=)")
     field(OUT,"@asyn($(PORT) $(OFFSET))$(DATA_TYPE)")
     info(asyn:INITIAL_READBACK, "$(INITIAL_READBACK=0)")
 }


### PR DESCRIPTION
The default template files do not have a desc field or macro, which I often have to add when I go to use them. This adds this missing desc field to all single record template files, with an empty default value in order to not break backwards compatibility. 